### PR TITLE
Add PIDs for Aiways U5

### DIFF
--- a/aiways/README.md
+++ b/aiways/README.md
@@ -1,0 +1,3 @@
+# Aiways u5 Data
+
+These OBD PIDs are based on the work by Valentin.

--- a/aiways/u5.json
+++ b/aiways/u5.json
@@ -1,108 +1,96 @@
 {
-  "init_commands": {
-    "command": ["ATD0", "ATE0", "ATSP6", "ATM0", "ATS0", "ATAL", "ATAT1", "ATST64", "ATSH703"]
-  },
-  "obd_protocol": "7",
-  "data_commands": {
-    "command": [
-      "221000",
-      "221001",
-      "221002",
-      "221004",
-      "221005",
-      "221006",
-      "221007",
-      "221009",
-      "221010",
-      "221202",
-      "221012",
-      "22DF05"
-    ]
-  },
-  "current": {
-    "equation": "(((signed(A)*256)+B)-7000)/10",
-    "minValue": "-500",
-    "maxValue": "300",
-    "type": "Number",
-    "command": "221005",
-    "ecu": ""
-  },
-  "voltage": {
-    "equation": "((signed(A)*256)+B)/10",
-    "minValue": "300",
-    "maxValue": "500",
-    "type": "Number",
-    "command": "221004",
-    "ecu": ""
-  },
-  "power": {
-    "equation": "current*voltage",
-    "minValue": "-250",
-    "maxValue": "250",
-    "type": "Number",
-    "ecu": ""
-  },
-  "batt_temp": {
-    "equation": "A-40",
-    "minValue": "-40",
-    "maxValue": "100",
-    "type": "Number",
-    "command": "221002",
-    "ecu": ""
-  },
-  "is_charging": {
-    "equation": "vehicle_reported_speed==0 && current>0",
-    "minValue": "0",
-    "maxValue": "1",
-    "type": "Boolean",
-    "ecu": ""
-  },
-  "soh": {
-    "equation": "A",
-    "minValue": "0",
-    "maxValue": "100",
-    "type": "Number",
-    "command": "221012",
-    "ecu": ""
-  },
-  "soc": {
-    "equation": "A",
-    "minValue": "0",
-    "maxValue": "100",
-    "type": "Number",
-    "command": "221006",
-    "ecu": ""
-  },
-  "soc_bms": {
-    "equation": "A",
-    "minValue": "0",
-    "maxValue": "100",
-    "type": "Number",
-    "command": "221007",
-    "ecu": ""
-  },
-  "soe": {
-    "equation": "A*63",
-    "minValue": "0",
-    "maxValue": "630",
-    "type": "Number",
-    "command": "221009",
-    "ecu": ""
-  },
-  "odometer": {
-    "equation": "(A*65536+B*256+C)/10",
-    "minValue": "0",
-    "maxValue": "1000000",
-    "type": "Number",
-    "command": "22DF05",
-    "ecu": ""
-  },
-  "vehicle_reported_speed": {
-    "equation": "((A*256)+b)/100",
-    "minValue": "0",
-    "maxValue": "200",
-    "type": "Number",
-    "command": "221202",
-    "ecu": ""
-  }
+    "init_commands": {
+        "command": [
+            "ATZ",
+            "ATD0",
+            "ATE0",
+            "ATSP6",
+            "ATM0",
+            "ATS0",
+            "ATAL",
+            "ATAT1",
+            "ATST64",
+            "ATSH703"
+        ]
+    },
+    "obd_protocol": "7",
+    "data_commands": {
+        "command": [
+            "221000",
+            "221001",
+            "221002",
+            "221004",
+            "221005",
+            "221006",
+            "221009",
+            "221010",
+            "221202",
+            "221012",
+            "22DF05"
+        ]
+    },
+    "current": {
+        "equation": "(((signed(A)*256)+B)-7000)/10",
+        "minValue": "-2000",
+        "maxValue": "2000",
+        "type": "Number",
+        "command": "221005",
+        "ecu": ""
+    },
+    "voltage": {
+        "equation": "((signed(A)*256)+B)/10",
+        "minValue": "300",
+        "maxValue": "500",
+        "type": "Number",
+        "command": "221004",
+        "ecu": ""
+    },
+    "batt_temp": {
+        "equation": "A-40",
+        "minValue": "-40",
+        "maxValue": "100",
+        "type": "Number",
+        "command": "221002",
+        "ecu": ""
+    },
+    "soh": {
+        "equation": "A",
+        "minValue": "50",
+        "maxValue": "105",
+        "type": "Number",
+        "command": "221012",
+        "ecu": ""
+    },
+    "soc": {
+        "equation": "A",
+        "minValue": "-5",
+        "maxValue": "105",
+        "type": "Number",
+        "command": "221006",
+        "ecu": ""
+    },
+    "soe": {
+        "equation": "A*6.3",
+        "minValue": "0",
+        "maxValue": "65",
+        "type": "Number",
+        "command": "221009",
+        "ecu": ""
+    },
+    "odometer": {
+        "equation": "(A*65536+B*256+C)/10",
+        "minValue": "0",
+        "maxValue": "1000000",
+        "type": "Number",
+        "command": "22DF05",
+        "ecu": ""
+    },
+    "vehicle_reported_speed": {
+        "equation": "((A*256)+b)/100",
+        "minValue": "0",
+        "maxValue": "200",
+        "type": "Number",
+        "command": "221202",
+        "ecu": ""
+    }
 }

--- a/aiways/u5.json
+++ b/aiways/u5.json
@@ -55,7 +55,7 @@
     "minValue": "0",
     "maxValue": "1",
     "type": "Boolean",
-    "ecu": "7E2"
+    "ecu": ""
   },
   "soh": {
     "equation": "A",

--- a/aiways/u5.json
+++ b/aiways/u5.json
@@ -1,0 +1,94 @@
+{
+  "init_commands": {
+    "command": ["ATD0", "ATE0", "ATSP6", "ATM0", "ATS0", "ATAL", "ATAT1", "ATST64", "ATSH703"]
+  },
+  "obd_protocol": "7",
+  "data_commands": {
+    "command": [
+      "221000",
+      "221001",
+      "221002",
+      "221004",
+      "221005",
+      "221006",
+      "221007",
+      "221009",
+      "221010",
+      "221202",
+      "221012",
+      "22DF05"
+    ]
+  },
+  "current": {
+    "equation": "(((signed(A)*256)+B)-7000)/10",
+    "minValue": "-500",
+    "maxValue": "300",
+    "type": "Number",
+    "command": "221005",
+    "ecu": ""
+  },
+  "voltage": {
+    "equation": "((A<<8)+B)*0.01",
+    "minValue": "300",
+    "maxValue": "500",
+    "type": "Number",
+    "command": "22480D",
+    "ecu": "7E4"
+  },
+  "batt_temp": {
+    "equation": "A-40",
+    "minValue": "-40",
+    "maxValue": "100",
+    "type": "Number",
+    "command": "221002",
+    "ecu": ""
+  },
+  "is_charging": {
+    "equation": "(A==6)||(A==8)",
+    "minValue": "0",
+    "maxValue": "1",
+    "type": "Boolean",
+    "command": "224851",
+    "ecu": "7E2"
+  },
+  "is_dcfc": {
+    "equation": "A==8",
+    "minValue": "0",
+    "maxValue": "1",
+    "type": "Boolean",
+    "command": "224851",
+    "ecu": "7E2"
+  },
+  "soh": {
+    "equation": "A*0.5",
+    "minValue": "-5",
+    "maxValue": "105",
+    "type": "Number",
+    "command": "22490C",
+    "ecu": "7E4"
+  },
+  "soc": {
+    "equation": "A*0.5",
+    "minValue": "-5",
+    "maxValue": "105",
+    "type": "Number",
+    "command": "224845",
+    "ecu": "7E4"
+  },
+  "odometer": {
+    "equation": "(A*65536+B*256+C)/10",
+    "minValue": "0",
+    "maxValue": "1000000",
+    "type": "Number",
+    "command": "22DF05",
+    "ecu": ""
+  },
+  "vehicle_reported_speed": {
+    "equation": "((A<<8)+B)/128",
+    "minValue": "0",
+    "maxValue": "200",
+    "type": "Number",
+    "command": "221505",
+    "ecu": "7E0"
+  }
+}

--- a/aiways/u5.json
+++ b/aiways/u5.json
@@ -28,12 +28,19 @@
     "ecu": ""
   },
   "voltage": {
-    "equation": "((A<<8)+B)*0.01",
+    "equation": "((signed(A)*256)+B)/10",
     "minValue": "300",
     "maxValue": "500",
     "type": "Number",
     "command": "22480D",
     "ecu": "7E4"
+  },
+  "power": {
+    "equation": "current*voltage",
+    "minValue": "-250",
+    "maxValue": "250",
+    "type": "Number",
+    "ecu": ""
   },
   "batt_temp": {
     "equation": "A-40",
@@ -44,7 +51,7 @@
     "ecu": ""
   },
   "is_charging": {
-    "equation": "(A==6)||(A==8)",
+    "equation": "vehicle_reported_speed==0 && current>0",
     "minValue": "0",
     "maxValue": "1",
     "type": "Boolean",
@@ -60,20 +67,36 @@
     "ecu": "7E2"
   },
   "soh": {
-    "equation": "A*0.5",
-    "minValue": "-5",
-    "maxValue": "105",
+    "equation": "A",
+    "minValue": "0",
+    "maxValue": "100",
     "type": "Number",
-    "command": "22490C",
-    "ecu": "7E4"
+    "command": "221012",
+    "ecu": ""
   },
   "soc": {
-    "equation": "A*0.5",
-    "minValue": "-5",
-    "maxValue": "105",
+    "equation": "A",
+    "minValue": "0",
+    "maxValue": "100",
     "type": "Number",
-    "command": "224845",
-    "ecu": "7E4"
+    "command": "221006",
+    "ecu": ""
+  },
+  "soc_bms": {
+    "equation": "A",
+    "minValue": "0",
+    "maxValue": "100",
+    "type": "Number",
+    "command": "221007",
+    "ecu": ""
+  },
+  "soe": {
+    "equation": "A*63",
+    "minValue": "0",
+    "maxValue": "630",
+    "type": "Number",
+    "command": "221009",
+    "ecu": ""
   },
   "odometer": {
     "equation": "(A*65536+B*256+C)/10",
@@ -84,11 +107,11 @@
     "ecu": ""
   },
   "vehicle_reported_speed": {
-    "equation": "((A<<8)+B)/128",
+    "equation": "((A*256)+b)/100",
     "minValue": "0",
     "maxValue": "200",
     "type": "Number",
-    "command": "221505",
-    "ecu": "7E0"
+    "command": "221202",
+    "ecu": ""
   }
 }

--- a/aiways/u5.json
+++ b/aiways/u5.json
@@ -32,8 +32,8 @@
     "minValue": "300",
     "maxValue": "500",
     "type": "Number",
-    "command": "22480D",
-    "ecu": "7E4"
+    "command": "221004",
+    "ecu": ""
   },
   "power": {
     "equation": "current*voltage",
@@ -55,15 +55,6 @@
     "minValue": "0",
     "maxValue": "1",
     "type": "Boolean",
-    "command": "224851",
-    "ecu": "7E2"
-  },
-  "is_dcfc": {
-    "equation": "A==8",
-    "minValue": "0",
-    "maxValue": "1",
-    "type": "Boolean",
-    "command": "224851",
     "ecu": "7E2"
   },
   "soh": {

--- a/obdble_cars.json
+++ b/obdble_cars.json
@@ -1,4 +1,8 @@
 {
+  "aiways:u5:*": {
+    "supports": ["calibration", "driving", "charging"],
+    "pids": "u5"
+  },
   "volkswagen:egolf:*": {
     "supports": ["calibration", "driving", "charging"],
     "pids": "eGolf"


### PR DESCRIPTION
Here are the PIDs for the Aiways U5, based of the work of the Aiways WhatsApp Community. I could not test any import function but adding these manually in ABRP worked with my vGate dongle.