### PR TITLE
Honda e:Ny1 config

### DIFF
--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -62,13 +62,6 @@
     "minValue": 0,
     "maxValue": 200000
   },
-  "power": {
-    "isVirtual": true,
-    "equation": "current*voltage/1000",
-    "type": "Number",
-    "min": -150,
-    "max": 150
-  },
   "soc": {
     "command": "22202A",
     "equation": "AY",

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -16,6 +16,7 @@
   "obd_protocol": "7",
   "data_commands": {
     "command": [
+      "ATSH18DA60F1",
       "ATCRA18DAF101",
       "22202A",
       "22202C",

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -1,0 +1,114 @@
+{
+  "init_commands": {
+    "command": [
+      "ATD",
+      "ATE0",
+      "ATH0",
+      "ATAT1",
+      "ATAL",
+      "ATS0",
+      "ATM0",
+      "ATSH18DA01F1",
+      "ATFCSH18DA01F1",
+      "ATFCSM1"
+    ]
+  },
+  "obd_protocol": "7",
+  "data_commands": {
+    "command": [
+      "ATCRA18DAF101",
+      "22202A",
+      "22202C",
+      "ATSH18DA60F1",
+      "ATCRA18DAF160",
+      "227022",
+      "227028",
+      "ATSH18DA01F1"
+    ]
+  },
+  "current": {
+    "command": "22202A",
+    "equation": "Int16(BF,BG) / 50",
+    "type": "Number",
+    "maxValue": 500,
+    "minValue": -500
+  },
+  "ext_temp": {
+    "command": "227028",
+    "equation": "R - 0",
+    "type": "Number",
+    "minValue": -40,
+    "maxValue": 60
+  },
+  "is_charging": {
+    "command": "22202A",
+    "equation": "ER == 00",
+    "type": "Boolean"
+  },
+  "is_dcfc": {
+    "command": "22202A",
+    "equation": "(ER==0)&&(FJ<252)",
+    "type": "Boolean"
+  },
+  "is_parked": {
+    "command": "224004",
+    "equation": "BB == 1",
+    "type": "Boolean"
+  },
+  "odometer": {
+    "command": "227022",
+    "equation": "Int24(G,H,I)",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 200000
+  },
+  "power": {
+    "isVirtual": true,
+    "equation": "current * voltage / 1000",
+    "type": "NUmber",
+    "min": -150,
+    "max": 150
+  },
+  "soc": {
+    "command": "22202A",
+    "equation": "AY",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 100
+  },
+  "soe": {
+    "command": "22202A",
+    "equation": "(AY / 100) * 62000",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 62000
+  },
+  "speed": {
+    "command": "227022",
+    "equation": "K * 1.60934",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 170
+  },
+  "vehicle_reported_speed": {
+    "command": "227022",
+    "equation": "K",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 110
+  },
+  "soh": {
+    "command": "22202A",
+    "equation": "II * 100 / 255",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 100
+  },
+  "voltage": {
+    "command": "22202A",
+    "equation": "Int16(BD,BE) / 20",
+    "type": "Number",
+    "minValue": 0,
+    "maxValue": 450
+  }
+}

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -66,8 +66,8 @@
     "command": "22202A",
     "equation": "AY",
     "type": "Number",
-    "minValue": 0,
-    "maxValue": 100
+    "minValue": -5,
+    "maxValue": 105
   },
   "soe": {
     "command": "22202A",

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -94,8 +94,8 @@
     "command": "22202A",
     "equation": "(II*100)/255",
     "type": "Number",
-    "minValue": 0,
-    "maxValue": 100
+    "minValue": 50,
+    "maxValue": 105
   },
   "voltage": {
     "command": "22202A",

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -28,7 +28,7 @@
   },
   "current": {
     "command": "22202A",
-    "equation": "Int16(BF,BG)/50",
+    "equation": "((Signed(BF)*256)+BG)/50",
     "type": "Number",
     "maxValue": 2000,
     "minValue": -2000

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -51,7 +51,7 @@
     "type": "Boolean"
   },
   "is_parked": {
-    "command": "224004",
+    "command": "22202A",
     "equation": "BB==1",
     "type": "Boolean"
   },

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -93,7 +93,7 @@
   },
   "voltage": {
     "command": "22202A",
-    "equation": "((BD<<8)+BE) / 20",
+    "equation": "((BD<<8)+BE)/20",
     "type": "Number",
     "minValue": 0,
     "maxValue": 450

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -29,7 +29,7 @@
   },
   "current": {
     "command": "22202A",
-    "equation": "((Signed(BF)*256)+BG)/50",
+    "equation": "((Signed(BF)*256)+BG)/100",
     "type": "Number",
     "maxValue": 2000,
     "minValue": -2000

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -30,8 +30,8 @@
     "command": "22202A",
     "equation": "Int16(BF,BG)/50",
     "type": "Number",
-    "maxValue": 500,
-    "minValue": -500
+    "maxValue": 2000,
+    "minValue": -2000
   },
   "ext_temp": {
     "command": "227028",

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -92,7 +92,7 @@
   },
   "voltage": {
     "command": "22202A",
-    "equation": "Int16(BD,BE)/20",
+    "equation": "((BD<<8)+BE) / 20",
     "type": "Number",
     "minValue": 0,
     "maxValue": 450

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -36,7 +36,7 @@
   },
   "ext_temp": {
     "command": "227028",
-    "equation": "R-0",
+    "equation": "R",
     "type": "Number",
     "minValue": -40,
     "maxValue": 60

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -58,7 +58,7 @@
   },
   "odometer": {
     "command": "227022",
-    "equation": "Int24(G,H,I)*1.60934",
+    "equation": "((G<<16)+(H<<8)+I)*1.60934",
     "type": "Number",
     "minValue": 0,
     "maxValue": 200000

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -21,28 +21,28 @@
       "22202C",
       "ATSH18DA60F1",
       "ATCRA18DAF160",
+      "224004",
       "227022",
-      "227028",
-      "ATSH18DA01F1"
+      "227028"
     ]
   },
   "current": {
     "command": "22202A",
-    "equation": "Int16(BF,BG) / 50",
+    "equation": "Int16(BF,BG)/50",
     "type": "Number",
     "maxValue": 500,
     "minValue": -500
   },
   "ext_temp": {
     "command": "227028",
-    "equation": "R - 0",
+    "equation": "R-0",
     "type": "Number",
     "minValue": -40,
     "maxValue": 60
   },
   "is_charging": {
     "command": "22202A",
-    "equation": "ER == 00",
+    "equation": "ER==0",
     "type": "Boolean"
   },
   "is_dcfc": {
@@ -52,20 +52,20 @@
   },
   "is_parked": {
     "command": "224004",
-    "equation": "BB == 1",
+    "equation": "BB==1",
     "type": "Boolean"
   },
   "odometer": {
     "command": "227022",
-    "equation": "Int24(G,H,I)",
+    "equation": "Int24(G,H,I)*1.60934",
     "type": "Number",
     "minValue": 0,
     "maxValue": 200000
   },
   "power": {
     "isVirtual": true,
-    "equation": "current * voltage / 1000",
-    "type": "NUmber",
+    "equation": "current*voltage/1000",
+    "type": "Number",
     "min": -150,
     "max": 150
   },
@@ -78,14 +78,14 @@
   },
   "soe": {
     "command": "22202A",
-    "equation": "(AY / 100) * 62000",
+    "equation": "(AY/100)*62000",
     "type": "Number",
     "minValue": 0,
     "maxValue": 62000
   },
   "speed": {
     "command": "227022",
-    "equation": "K * 1.60934",
+    "equation": "K*1.60934",
     "type": "Number",
     "minValue": 0,
     "maxValue": 170
@@ -99,14 +99,14 @@
   },
   "soh": {
     "command": "22202A",
-    "equation": "II * 100 / 255",
+    "equation": "(II*100)/255",
     "type": "Number",
     "minValue": 0,
     "maxValue": 100
   },
   "voltage": {
     "command": "22202A",
-    "equation": "Int16(BD,BE) / 20",
+    "equation": "Int16(BD,BE)/20",
     "type": "Number",
     "minValue": 0,
     "maxValue": 450

--- a/honda/eny1.json
+++ b/honda/eny1.json
@@ -76,19 +76,12 @@
     "minValue": 0,
     "maxValue": 62000
   },
-  "speed": {
+  "vehicle_reported_speed": {
     "command": "227022",
     "equation": "K*1.60934",
     "type": "Number",
     "minValue": 0,
     "maxValue": 170
-  },
-  "vehicle_reported_speed": {
-    "command": "227022",
-    "equation": "K",
-    "type": "Number",
-    "minValue": 0,
-    "maxValue": 110
   },
   "soh": {
     "command": "22202A",

--- a/obdble_cars.json
+++ b/obdble_cars.json
@@ -121,5 +121,9 @@
     "supports": ["calibration", "driving", "charging"],
     "pids": "mgzsev",
     "groups": ["tester"]
-  }
+  },
+  "honda:eny1:26*": {
+    "supports": ["calibration", "driving", "charging"],
+    "pids": "eny1"
+}
 }


### PR DESCRIPTION
Hi, this PR adds PIDs for the Honda e:Ny1.

Notes:

1. `ext_temp` did not work with `R`, but does work with `R-0`.

2. `odometer` appears to need converting from miles to kilometres to display correctly in ABRP Live Data. I believe the included equation is correct, but would appreciate confirmation.

3. I assumed `speed` would also need converting, so I tested `speed` in km/h and `vehicle_reported_speed` in mph. In the PID test, both reported the same value. I cannot see the speed displayed elsewhere in ABRP, so I would appreciate confirmation on which is correct.

4. I am still working on `batt_temp`. Early indications suggest it may come from `22202C` byte `FN`, but the equation is very likely not correct yet, so I have not included it in this PR. For reference, the current working theory is:
```
"batt_temp": {
  "command": "22202C",
  "equation": "FN-50",
  "type": "Number",
  "minValue": -40,
  "maxValue": 60
}
```