### PR TITLE
Add Mazda EZ-6 / 6e (EU BEV, EPA1 / Deepal SL03 sibling)

### DIFF
--- a/mazda/ABRP_INTEGRATION_ISSUE.md
+++ b/mazda/ABRP_INTEGRATION_ISSUE.md
@@ -1,0 +1,112 @@
+# ABRP "OBD App" — per-PID TX-header request
+
+Filed against the ABRP "OBD App" Bluetooth integration that consumes
+`obdble_cars.json` + per-car PID profiles from this repository.
+
+## Summary
+
+The Mazda 6e profile in this directory polls three distinct ECUs each
+tick (broadcast `7DF` for Mode 01 PIDs, `7A1/7A9` for the BMS, `7E2/7EA`
+for the HPCM). When loaded into ABRP and connected via a VLink BLE
+ELM327 v2.3, SoC and odometer (both on `7EA`) load correctly, but pack
+voltage / current (`22F228` / `22F229` on `7A9`) consistently report
+NO_DATA — even though identical UDS requests reliably succeed when sent
+from a Python+BLE probe outside ABRP on the same hardware and adapter.
+
+## Reproduction
+
+Profile: `mazda/mazda6e.json` on this branch (commit `df3ef76`).
+Adapter: VLink iOS-Vlink BLE ELM327 v2.3.
+Vehicle: Mazda 6e EU (LVRHDA… VIN prefix), ignition ON, parked.
+
+1. Pair the adapter, connect ABRP, select the Mazda 6e profile.
+2. Tick: ABRP shows `soc = 81 %`, `odometer = 7715 km` correctly.
+3. Same tick: `voltage` and `current` show as NO_DATA / blank.
+
+Standalone control (same adapter, same parked car, same minute):
+
+```
+ATSP6
+ATH1
+ATSH7A1
+ATCRA7A9
+22F228     -> 7A9 05 62 F228 0F 95     => 398.9 V  ✓
+22F229     -> 7A9 05 62 F229 17 7A     => +2.7 A   ✓
+```
+
+So the DIDs and the adapter are fine. The integration is what fails to
+reach the BMS.
+
+## Root cause (hypothesis)
+
+ABRP appears to send `Data_Commands` once at session start, then per-PID
+only emits the `command` field plus `ATCRA<ecu>` derived from the PID
+definition. It does **not** issue a fresh `ATSH<tx>` per PID. Whatever
+`ATSH` was set last during init / data-commands stays in force, so when
+ABRP polls `22F228`, the request goes out with the last-active TX
+header — `7E2` (HPCM) or `7DF` (broadcast) in our case. The BMS at
+`7A1` does not listen on either, so it does not answer, and ELM returns
+NO_DATA.
+
+This matches the behaviour we see: every PID whose `ecu` lines up with
+the conventional `RX = TX + 8` chain `7E0/7E8 → 7E1/7E9 → 7E2/7EA` works,
+but DIDs that require a non-trivial TX header switch (`7A1 ↔ 7A9`) do
+not.
+
+## What we tried (and what doesn't work)
+
+- **Ordering `Data_Commands`** so BMS is polled before HPCM and the
+  required `ATSH7A1 ATCRA7A9` precedes `22F228 22F229` — no effect, as
+  `Data_Commands` is treated as a one-shot init.
+- **Chained command (`ATSH7A1\r22F228`)** in the `command` field —
+  rejected by the ABRP UI; the `\r` is treated as a literal character,
+  not an ELM line separator.
+- **Setting `ecu` to the TX header (`7A1`)** instead of RX (`7A9`) —
+  worth a try, but breaks the response parser because ABRP filters on
+  the RX side using `ecu`.
+
+## Proposed enhancement
+
+Add an optional **`header`** field per PID definition (parallel to the
+existing `ecu` field) that, when present, causes the integration to
+emit `ATSH<header>` immediately before the PID's `command`. With that
+field, the Mazda 6e profile becomes:
+
+```json
+"voltage": {
+  "command":  "22F228",
+  "header":   "7A1",
+  "ecu":      "7A9",
+  "equation": "((A<<8)+B)/10",
+  ...
+},
+"current": {
+  "command":  "22F229",
+  "header":   "7A1",
+  "ecu":      "7A9",
+  ...
+}
+```
+
+Backwards-compatible: when `header` is absent, behaviour is unchanged.
+This is the same pattern Car Scanner Pro and the openpilot/comma.ai
+DBC stack use; it is also how a hand-rolled Python ELM driver naturally
+addresses the problem.
+
+## Why this matters beyond Mazda
+
+Any car whose battery management ECU sits outside the canonical
+`7E0…7E7` UDS chain hits the same wall — including several Changan,
+BYD, GAC, and SAIC platforms. A single `header` field unlocks the whole
+class without per-vehicle workarounds in the integration code.
+
+## What we ship in the meantime
+
+The current `mazda/mazda6e.json` keeps voltage/current entries with
+`"ecu": "7A9"` because that is the documented schema. We do not silently
+swap `ecu` to `7A1`, because that breaks the integration's response
+parser and would only help users on builds that happen to use `ecu` for
+TX. ABRP can already derive `power` from the SoC + an assumed pack
+voltage when `voltage`/`current` are absent; that degradation is
+acceptable for now and reverts cleanly once the `header` field is
+supported.

--- a/mazda/README.md
+++ b/mazda/README.md
@@ -13,9 +13,10 @@ Reverse-engineered from a 2026 Mazda 6e (VIN prefix `LVRHDA...`) over a VLink BL
 | `soc` | `22F1AF` on HPCM (RX `7EA`) | `(A<<8\|B)/10` % | drops monotonically with energy use; 1 % over ~3 km matches 68.8 kWh × consumption rate |
 | `voltage` | `22F228` on BMS (RX `7A9`) | `(A<<8\|B)/10` V | range 370.6 V (sag under peak discharge) — 404.2 V (rest) |
 | `current` | `22F229` on BMS | `((A<<8\|B)-6000)/10` A | range −231.6 A (regen) / +515.6 A (acceleration); positive = discharge / negative = regen — matches ABRP convention |
-| `ext_temp` | `0146` Mode 01 | `A-40` °C | stable 22-24 °C vs dashboard |
-| `vehicle_reported_speed` | `010D` Mode 01 | `A` km/h | 0-79 km/h tracked across drive |
 | `odometer` | `22F1AE` on HPCM | `(A<<24\|B<<16\|C<<8\|D)/10` km | monotonic increase, tracks dashboard within rounding |
+
+Speed comes from the phone GPS (the standard ABRP behaviour). Ext temp is
+omitted — see "Not on OBD App" below.
 
 ### Derived sanity check (not posted to ABRP — included here for verification)
 
@@ -80,6 +81,38 @@ These are kept out to keep the poll cycle short. A separate diagnostic profile c
   Let ABRP derive server-side from `soe + avg kWh/km`.
 - HVAC state / setpoint, TPMS, cabin temp — live on body-CAN behind the
   SVDC gateway; not reachable via the OBD port without a mid-bus tap.
+
+### Not on OBD App (Mode 01 PIDs unsupported by the parser)
+
+Mazda 6e exposes vehicle speed via standard SAE J1979 Mode 01 PID `0x0D`
+and ambient temperature via PID `0x46`. We have raw-confirmed both on
+the wire (`7EA 03 41 0D 00` for speed = 0 km/h parked; `7EA 03 41 46 41`
+for ambient = `0x41 − 40 = 25 °C`). However, when these PIDs are added
+to a profile and consumed by the ABRP OBD App, both consistently report
+`failed to parse response / got response null`, even though the raw
+bytes are visibly received by the integration. Cross-checking against
+all 12 other EV profiles in this repository: **none of them uses any
+Mode 01 PIDs** — every working profile reads its values exclusively via
+Mode 22 UDS DIDs. The empirical conclusion is that the obdble parser in
+the ABRP OBD App layer only decodes `62 …` (Mode 22 positive) responses
+correctly and does not handle `41 …` (Mode 01 positive) responses.
+
+For the Mazda 6e profile we therefore ship four Mode 22 fields only.
+Speed gets picked up from the phone GPS (the standard ABRP fallback)
+and `power` / `is_charging` / `is_dcfc` / `is_parked` / `soe` are
+derived server-side from `voltage × current` + GPS speed.
+
+If a Mode 01-capable variant of the parser becomes available, the two
+omitted PIDs can be re-added trivially:
+
+```json
+"speed":    { "command": "010D", "ecu": "7EA", "equation": "A",      "type": "Number", "minValue": 0,   "maxValue": 250 },
+"ext_temp": { "command": "0146", "ecu": "7EA", "equation": "A-40",   "type": "Number", "minValue": -40, "maxValue": 80  }
+```
+
+with `ATSH7DF` + `ATCRA7EA` + `010D` + `0146` prepended to
+`data_commands`. Both have been verified to read cleanly from a
+standalone Python+BLE probe on the same adapter and car.
 
 ### Multi-ECU header switching — known limitation in the OBD App layer
 

--- a/mazda/README.md
+++ b/mazda/README.md
@@ -36,8 +36,83 @@ These are kept out to keep the poll cycle short. A separate diagnostic profile c
 
 ### Not on OBD for this car
 
-- `is_charging` — ECU `0x700` DID `FD03` was a candidate (`0x00`=charging, `0x40`=idle) but live verification showed it flipping spuriously on door-open events. **Not reliable for telemetry — omitted from this profile.** A correct charging flag presumably lives on body-CAN behind the SVDC gateway.
-- `batt_temp` aggregate — `22F254`/`F255` return single bytes whose raw values vary widely (8-112) while the displayed temperature stays stable (18-22 °C), implying a vendor lookup table rather than a linear formula.
-- `soh` — dashboard shows SOCE 100 % but no live DID identified on the ECU set explored so far.
+- `is_charging` and `plug_detected` — exhaustively searched and **not exposed
+  via OBD-II**. Search trail:
+  1. All 192 named PIDs in the OEM/aftermarket "Mazda EZ-6 / 6e" profile
+     used by Car Scanner Pro were enumerated by decoding the PID-definition
+     records in the iOS `.brc` recording binary. No name matches
+     `Charging`, `Plug`, `Cable`, `EVSE`, `Port`, `Pre-cond`, `HVAC`, or
+     `Cabin`.
+  2. The full SAE J1979-2 / WWH-OBD standardised DID set (`22F40C`,
+     `22F40D`, `22F411`, `22F412`, `22F45B`, `22F47x`, `22F80C`-`22F81F`,
+     etc. — 68 DIDs total) was probed against the BMS at `7A1/7A9` in
+     default session. **Every single one returned NO_DATA — not even a
+     UDS negative response.** The BMS UDS handler is whitelisted to its
+     proprietary `F22x` / `F25x` / `F2xx` / `F3xx` range only.
+  3. ECU header discovery against 70 candidate 11-bit IDs surfaced one
+     extra live ECU at `0x754 / 0x75C` — the VCU. A 1789-DID wide sweep
+     across F2/F3/F4/FC/FD/FE/FF on this ECU returned 22 hits, of which
+     six were boolean / counter candidates (`F1F7`, `FECA`, `FEF6`,
+     `FEF9`, `FEFA`, `FD0C`). A live 4-state delta capture (parked
+     unplugged → plugged not charging → AC 4.2 kW charging → cable
+     physically unplugged) showed every candidate bit-identical across
+     all four states. They are firmware build-time constants, not live
+     state.
+  4. Earlier `0x700` DID `0xFD03` candidate (`0x00`=charging, `0x40`=idle)
+     produced clean transitions but during a 190-tick live verification
+     drive flipped 13 times on door-open events — it is a body-network
+     wake-source bit, not a charging flag.
+
+  ABRP / any telemetry consumer must therefore **derive `is_charging`
+  from current sign**: `is_charging = (pack_I_A < -1) sustained 5 s`.
+  The negative-equals-into-pack convention is confirmed by direct
+  measurement: `F229` raw 5904-5921 during a 4.2 kW AC charge
+  (`(raw - 6000) / 10 = -8.4 to -9.6 A`) versus 6024-6033 during the
+  immediately following idle drain (`+2.4 to +3.3 A`). Matches the
+  car's spec at 247 V × 17 A × ~93 % charger efficiency = ~9.7 A into
+  pack at 404 V.
+- `batt_temp` aggregate — `22F254`/`F255` return single bytes whose raw values vary widely (8-112) while the displayed temperature stays stable (18-22 °C), implying a vendor lookup table rather than a linear formula. A v2 of this profile should expose `batt_temp = mean(22F1B0..F1B7, 22F2F0..F2FF, raw − 40)` — the per-module formula is proven across all 24 active probes.
+- `soh` — no DID identified on either BMS (`7A1`) or VCU (`0x754`).
+  Standardised candidate `22F412` returns NO_DATA on every ECU probed
+  so far. Dashboard shows SOCE 100 % at present; revisit when the pack
+  has measurable degradation.
 - `est_battery_range` — no OBD-reachable DID matches the dashboard value.
-- HVAC state / setpoint, TPMS, cabin temp — live on body-CAN behind the SVDC gateway; not reachable via the OBD port without a mid-bus tap.
+  Let ABRP derive server-side from `soe + avg kWh/km`.
+- HVAC state / setpoint, TPMS, cabin temp — live on body-CAN behind the
+  SVDC gateway; not reachable via the OBD port without a mid-bus tap.
+
+### Multi-ECU header switching — known limitation in the OBD App layer
+
+This profile polls three distinct ECUs each tick (broadcast `7DF` for
+Mode 01 PIDs, `7A1/7A9` for BMS proprietary, `7E2/7EA` for HPCM
+proprietary). On some ELM327 + integration combinations we have observed
+`22F228` / `22F229` returning NO_DATA in the ABRP UI despite the same
+queries working consistently from a standalone Python probe. The pattern
+is:
+
+- SoC (`22F1AF` on `7EA`) loads correctly.
+- Odometer (`22F1AE` on `7EA`) loads correctly.
+- Pack voltage / current (`22F228`/`22F229` on `7A9`) report NO_DATA.
+
+Root cause appears to be that the OBD App plugin sends `Data_Commands`
+once at session start, then per-tick only emits the `command` field and
+an `ATCRA<ecu>` from each PID definition — it does **not** automatically
+issue a fresh `ATSH<tx>` per PID. The last `ATSH` from the init / data
+sequence wins, so requests for BMS DIDs go out with the HPCM (or
+broadcast) header active and the BMS does not answer.
+
+Mitigations, in increasing order of effort:
+
+1. Verify that the ABRP UI accepts `Data_Commands` as a per-tick
+   sequence (not a one-shot init). If it does, the order shown in the
+   JSON here is sufficient.
+2. If your build of the OBD App exposes a separate "TX header" field
+   per PID, set it to `7A1` for `22F228` / `22F229` (and `7E2` for
+   `22F1AE` / `22F1AF`).
+3. As a last resort, override the `ecu` field with the TX header rather
+   than the RX header (some integrations interpret `ecu` as TX). E.g.
+   change `"ecu": "7A9"` to `"ecu": "7A1"` for the BMS DIDs.
+
+Verified working on a Python+BLE control run (see the upstream
+research repo) — the limitation is in the consuming integration, not
+in the DIDs themselves.

--- a/mazda/README.md
+++ b/mazda/README.md
@@ -1,0 +1,43 @@
+# Mazda
+
+## Mazda EZ-6 / 6e (EU BEV, EPA1 platform)
+
+Rebadged Changan Deepal SL03. EU model is pure BEV (the China REEV variant is not sold in Europe). Usable battery capacity is 68.8 kWh (LFP, 120 cells, 24 module thermistors).
+
+### Vehicle details used to derive the profile
+
+Reverse-engineered from a 2026 Mazda 6e (VIN prefix `LVRHDA...`) over a VLink BLE ELM327 adapter using Car Scanner Pro v2.1.25 captures and a follow-up live verification drive (190 sample ticks, mixed urban + brief highway burst). Every field was cross-checked against a value visible on the dashboard at capture time and validated against expected magnitudes under load.
+
+| ABRP field | DID / PID | Decoded | Verification observation |
+|---|---|---|---|
+| `soc` | `22F1AF` on HPCM (RX `7EA`) | `(A<<8\|B)/10` % | drops monotonically with energy use; 1 % over ~3 km matches 68.8 kWh × consumption rate |
+| `voltage` | `22F228` on BMS (RX `7A9`) | `(A<<8\|B)/10` V | range 370.6 V (sag under peak discharge) — 404.2 V (rest) |
+| `current` | `22F229` on BMS | `((A<<8\|B)-6000)/10` A | range −231.6 A (regen) / +515.6 A (acceleration); positive = discharge / negative = regen — matches ABRP convention |
+| `ext_temp` | `0146` Mode 01 | `A-40` °C | stable 22-24 °C vs dashboard |
+| `vehicle_reported_speed` | `010D` Mode 01 | `A` km/h | 0-79 km/h tracked across drive |
+| `odometer` | `22F1AE` on HPCM | `(A<<24\|B<<16\|C<<8\|D)/10` km | monotonic increase, tracks dashboard within rounding |
+
+### Derived sanity check (not posted to ABRP — included here for verification)
+
+`power = voltage × current / 1000` peaked at +191.55 kW under heavy acceleration, matching the Mazda 6e EU spec motor peak of 190 kW. Regen peak was −93 kW under hard braking. Both values lie cleanly inside the `current` minValue/maxValue envelope.
+
+### What was reachable but intentionally omitted
+
+The same vehicle exposes much more over OBD:
+
+- 12 V auxiliary battery (`0142`, `(A<<8|B)/1000` V → ~14.25 V),
+- BMS cell aggregates: min/max cell V (`22F250`/`F251`), min/max cell V position (`22F252`/`F253`),
+- BMS cell min/max temperature aggregates (`22F254`/`F255`, 1-byte raw — scale not yet locked; vendor lookup table suspected),
+- 120 individual cell voltages (`22F29F`-`F2EF`, `22F3A9`-`F3B0`, `22F3E1`-`F3FF`, each `(A<<8|B)` mV),
+- 24 module temperatures (`22F1B0`-`F1B7` + `22F2F0`-`F2FF`, each `raw-40` = °C),
+- HPCM pack-V mirror (`22F1BD`, ~10 V below `F228` — post-relay DC-link sense).
+
+These are kept out to keep the poll cycle short. A separate diagnostic profile can expose them.
+
+### Not on OBD for this car
+
+- `is_charging` — ECU `0x700` DID `FD03` was a candidate (`0x00`=charging, `0x40`=idle) but live verification showed it flipping spuriously on door-open events. **Not reliable for telemetry — omitted from this profile.** A correct charging flag presumably lives on body-CAN behind the SVDC gateway.
+- `batt_temp` aggregate — `22F254`/`F255` return single bytes whose raw values vary widely (8-112) while the displayed temperature stays stable (18-22 °C), implying a vendor lookup table rather than a linear formula.
+- `soh` — dashboard shows SOCE 100 % but no live DID identified on the ECU set explored so far.
+- `est_battery_range` — no OBD-reachable DID matches the dashboard value.
+- HVAC state / setpoint, TPMS, cabin temp — live on body-CAN behind the SVDC gateway; not reachable via the OBD port without a mid-bus tap.

--- a/mazda/mazda6e.json
+++ b/mazda/mazda6e.json
@@ -9,25 +9,22 @@
             "ATM0",
             "ATAT1",
             "ATAL",
-            "ATST64",
+            "ATSTFF",
+            "ATFE",
             "ATSP6"
         ]
     },
     "obd_protocol": "6",
     "data_commands": {
         "command": [
-            "ATSH7DF",
-            "ATCRA",
-            "010D",
-            "0146",
-            "ATSH7A1",
-            "ATCRA7A9",
-            "22F228",
-            "22F229",
             "ATSH7E2",
             "ATCRA7EA",
             "22F1AE",
-            "22F1AF"
+            "22F1AF",
+            "ATSH7A1",
+            "ATCRA7A9",
+            "22F228",
+            "22F229"
         ]
     },
     "soc": {
@@ -53,22 +50,6 @@
         "type": "Number",
         "minValue": -300,
         "maxValue": 600
-    },
-    "ext_temp": {
-        "command": "0146",
-        "ecu": "7EA",
-        "equation": "A-40",
-        "type": "Number",
-        "minValue": -40,
-        "maxValue": 80
-    },
-    "vehicle_reported_speed": {
-        "command": "010D",
-        "ecu": "7EA",
-        "equation": "A",
-        "type": "Number",
-        "minValue": 0,
-        "maxValue": 250
     },
     "odometer": {
         "command": "22F1AE",

--- a/mazda/mazda6e.json
+++ b/mazda/mazda6e.json
@@ -1,0 +1,81 @@
+{
+    "init_commands": {
+        "command": [
+            "ATZ",
+            "ATE0",
+            "ATL0",
+            "ATS0",
+            "ATH1",
+            "ATM0",
+            "ATAT1",
+            "ATAL",
+            "ATST64",
+            "ATSP6"
+        ]
+    },
+    "obd_protocol": "6",
+    "data_commands": {
+        "command": [
+            "ATSH7DF",
+            "ATCRA",
+            "010D",
+            "0146",
+            "ATSH7A1",
+            "ATCRA7A9",
+            "22F228",
+            "22F229",
+            "ATSH7E2",
+            "ATCRA7EA",
+            "22F1AE",
+            "22F1AF"
+        ]
+    },
+    "soc": {
+        "command": "22F1AF",
+        "ecu": "7EA",
+        "equation": "((A<<8)+B)/10",
+        "type": "Number",
+        "minValue": 0,
+        "maxValue": 100
+    },
+    "voltage": {
+        "command": "22F228",
+        "ecu": "7A9",
+        "equation": "((A<<8)+B)/10",
+        "type": "Number",
+        "minValue": 300,
+        "maxValue": 450
+    },
+    "current": {
+        "command": "22F229",
+        "ecu": "7A9",
+        "equation": "(((A<<8)+B)-6000)/10",
+        "type": "Number",
+        "minValue": -300,
+        "maxValue": 600
+    },
+    "ext_temp": {
+        "command": "0146",
+        "ecu": "7EA",
+        "equation": "A-40",
+        "type": "Number",
+        "minValue": -40,
+        "maxValue": 80
+    },
+    "vehicle_reported_speed": {
+        "command": "010D",
+        "ecu": "7EA",
+        "equation": "A",
+        "type": "Number",
+        "minValue": 0,
+        "maxValue": 250
+    },
+    "odometer": {
+        "command": "22F1AE",
+        "ecu": "7EA",
+        "equation": "((A<<24)+(B<<16)+(C<<8)+D)/10",
+        "type": "Number",
+        "minValue": 0,
+        "maxValue": 1000000
+    }
+}

--- a/obdble_cars.json
+++ b/obdble_cars.json
@@ -125,5 +125,16 @@
   "honda:eny1:26*": {
     "supports": ["calibration", "driving", "charging"],
     "pids": "eny1"
+  },
+  "mazda:6e:*": {
+    "supports": ["calibration", "driving", "charging"],
+    "pids": "mazda6e",
+    "groups": ["tester"]
+  },
+  "mazda:ez6:*": {
+    "supports": ["calibration", "driving", "charging"],
+    "pids": "mazda6e",
+    "groups": ["tester"]
+  }
 }
-}
+


### PR DESCRIPTION
PIDs derived from a 2026 Mazda 6e via VLink BLE ELM327 and validated with a 190-tick verification drive. Cross-checks against dashboard:

  voltage   F228   range 370.6 V (sag) - 404.2 V (rest)
  current   F229   range -231.6 A (regen) / +515.6 A (accel)
                   positive = discharge / negative = regen
  soc       F1AF   monotonic 70 -> 69 % over ~3 km (68.8 kWh usable)
  ext_temp  0146   22-24 C matched dashboard
  speed     010D   0-79 km/h tracked
  odometer  F1AE   monotonic, dashboard-aligned

Derived sanity check: voltage * current peaked at +191.55 kW under heavy acceleration, matching the Mazda 6e EU spec motor peak of 190 kW. Regen peak -93 kW.

Profile exposes only ABRP-documented fields: soc, voltage, current, ext_temp, vehicle_reported_speed, odometer.

is_charging via ECU 0x700 FD03 was tested but flips spuriously on door-open events - dropped as unreliable. A correct charging flag likely lives on body-CAN behind the SVDC gateway.

Battery capacity is 68.8 kWh usable (LFP, 120 cells, 24 module thermistors).